### PR TITLE
Fix conflicts with original library

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Full API documentation is available here: https://pubsubclient.knolleary.net
 
  - It can only publish QoS 0 messages. It can subscribe at QoS 0 or QoS 1.
  - The maximum message size, including header, is **256 bytes** by default. This
-   is configurable via `MQTT_MAX_PACKET_SIZE` in `TBPubSubClient.h` or can be changed
-   by calling `TBPubSubClient::setBufferSize(size)`.
+   is configurable via `MQTT_MAX_PACKET_SIZE` in `PubSubClient.h` or can be changed
+   by calling `PubSubClient::setBufferSize(size)`.
  - The keepalive interval is set to 15 seconds by default. This is configurable
-   via `MQTT_KEEPALIVE` in `TBPubSubClient.h` or can be changed by calling
-   `TBPubSubClient::setKeepAlive(keepAlive)`.
+   via `MQTT_KEEPALIVE` in `PubSubClient.h` or can be changed by calling
+   `PubSubClient::setKeepAlive(keepAlive)`.
  - The client uses MQTT 3.1.1 by default. It can be changed to use MQTT 3.1 by
-   changing value of `MQTT_VERSION` in `TBPubSubClient.h`.
+   changing value of `MQTT_VERSION` in `PubSubClient.h`.
 
 
 ## Compatible Hardware
@@ -42,7 +42,7 @@ boards and shields, including:
  - Arduino YUN – use the included `YunClient` in place of `EthernetClient`, and
    be sure to do a `Bridge.begin()` first
  - Arduino WiFi Shield - if you want to send packets > 90 bytes with this shield,
-   enable the `MQTT_MAX_TRANSFER_SIZE` define in `TBPubSubClient.h`.
+   enable the `MQTT_MAX_TRANSFER_SIZE` define in `PubSubClient.h`.
  - Sparkfun WiFly Shield – [library](https://github.com/dpslwk/WiFly)
  - TI CC3000 WiFi - [library](https://github.com/sparkfun/SFE_CC3000_Library)
  - Intel Galileo/Edison

--- a/examples/mqtt_auth/mqtt_auth.ino
+++ b/examples/mqtt_auth/mqtt_auth.ino
@@ -9,7 +9,7 @@
 
 #include <SPI.h>
 #include <Ethernet.h>
-#include <TBPubSubClient.h>
+#include <PubSubClient.h>
 
 // Update these with values suitable for your network.
 byte mac[]    = {  0xDE, 0xED, 0xBA, 0xFE, 0xFE, 0xED };

--- a/examples/mqtt_basic/mqtt_basic.ino
+++ b/examples/mqtt_basic/mqtt_basic.ino
@@ -15,7 +15,7 @@
 
 #include <SPI.h>
 #include <Ethernet.h>
-#include <TBPubSubClient.h>
+#include <PubSubClient.h>
 
 // Update these with values suitable for your network.
 byte mac[]    = {  0xDE, 0xED, 0xBA, 0xFE, 0xFE, 0xED };

--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -19,7 +19,7 @@
 */
 
 #include <ESP8266WiFi.h>
-#include <TBPubSubClient.h>
+#include <PubSubClient.h>
 
 // Update these with values suitable for your network.
 

--- a/examples/mqtt_large_message/mqtt_large_message.ino
+++ b/examples/mqtt_large_message/mqtt_large_message.ino
@@ -25,7 +25,7 @@
 */
 
 #include <ESP8266WiFi.h>
-#include <TBPubSubClient.h>
+#include <PubSubClient.h>
 
 // Update these with values suitable for your network.
 

--- a/examples/mqtt_publish_in_callback/mqtt_publish_in_callback.ino
+++ b/examples/mqtt_publish_in_callback/mqtt_publish_in_callback.ino
@@ -16,7 +16,7 @@
 
 #include <SPI.h>
 #include <Ethernet.h>
-#include <TBPubSubClient.h>
+#include <PubSubClient.h>
 
 // Update these with values suitable for your network.
 byte mac[]    = {  0xDE, 0xED, 0xBA, 0xFE, 0xFE, 0xED };

--- a/examples/mqtt_reconnect_nonblocking/mqtt_reconnect_nonblocking.ino
+++ b/examples/mqtt_reconnect_nonblocking/mqtt_reconnect_nonblocking.ino
@@ -10,7 +10,7 @@
 
 #include <SPI.h>
 #include <Ethernet.h>
-#include <TBPubSubClient.h>
+#include <PubSubClient.h>
 
 // Update these with values suitable for your hardware/network.
 byte mac[]    = {  0xDE, 0xED, 0xBA, 0xFE, 0xFE, 0xED };

--- a/examples/mqtt_stream/mqtt_stream.ino
+++ b/examples/mqtt_stream/mqtt_stream.ino
@@ -11,7 +11,7 @@
 
 #include <SPI.h>
 #include <Ethernet.h>
-#include <TBPubSubClient.h>
+#include <PubSubClient.h>
 #include <SRAM.h>
 
 // Update these with values suitable for your network.

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
         "type": "git",
         "url": "https://github.com/thingsboard/pubsubclient.git"
     },
-    "version": "2.9.2",
+    "version": "2.9.3",
     "exclude": "tests",
     "examples": "examples/*/*.ino",
     "frameworks": "arduino",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TBPubSubClient
-version=2.9.2
+version=2.9.3
 author=Nick O'Leary <nick.oleary@gmail.com>
 maintainer=ThingsBoard Team
 sentence=A client library for MQTT messaging.

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -5,7 +5,7 @@
   http://knolleary.net
 */
 
-#include "TBPubSubClient.h"
+#include "PubSubClient.h"
 #include "Arduino.h"
 
 PubSubClient::PubSubClient() {

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -4,8 +4,8 @@
   http://knolleary.net
 */
 
-#ifndef TBPubSubClient_h
-#define TBPubSubClient_h
+#ifndef PubSubClient_h
+#define PubSubClient_h
 
 #include <Arduino.h>
 #include "IPAddress.h"

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -1,5 +1,5 @@
 /*
- TBPubSubClient.h - A simple client for MQTT.
+ PubSubClient.h - A simple client for MQTT.
   Nick O'Leary
   http://knolleary.net
 */

--- a/tests/src/connect_spec.cpp
+++ b/tests/src/connect_spec.cpp
@@ -1,4 +1,4 @@
-#include "TBPubSubClient.h"
+#include "PubSubClient.h"
 #include "ShimClient.h"
 #include "Buffer.h"
 #include "BDDTest.h"

--- a/tests/src/keepalive_spec.cpp
+++ b/tests/src/keepalive_spec.cpp
@@ -1,4 +1,4 @@
-#include "TBPubSubClient.h"
+#include "PubSubClient.h"
 #include "ShimClient.h"
 #include "Buffer.h"
 #include "BDDTest.h"

--- a/tests/src/publish_spec.cpp
+++ b/tests/src/publish_spec.cpp
@@ -1,4 +1,4 @@
-#include "TBPubSubClient.h"
+#include "PubSubClient.h"
 #include "ShimClient.h"
 #include "Buffer.h"
 #include "BDDTest.h"

--- a/tests/src/receive_spec.cpp
+++ b/tests/src/receive_spec.cpp
@@ -1,4 +1,4 @@
-#include "TBPubSubClient.h"
+#include "PubSubClient.h"
 #include "ShimClient.h"
 #include "Buffer.h"
 #include "BDDTest.h"

--- a/tests/src/subscribe_spec.cpp
+++ b/tests/src/subscribe_spec.cpp
@@ -1,4 +1,4 @@
-#include "TBPubSubClient.h"
+#include "PubSubClient.h"
 #include "ShimClient.h"
 #include "Buffer.h"
 #include "BDDTest.h"


### PR DESCRIPTION
Renamed header and implementation file to fix conflicts when using with the original library. See https://github.com/thingsboard/thingsboard-client-sdk/issues/165 for more information.

Would be nice if this could be merged @imbeacon. So I can include it in the next ThingsBoard release, to fix the aforementioned issue.