### PR TITLE
fix compiler warning

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -441,13 +441,13 @@ boolean PubSubClient::publish(const char* topic, const char* payload, boolean re
     return publish(topic,(const uint8_t*)payload, payload ? strnlen(payload, this->bufferSize) : 0,retained);
 }
 
-boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigned int plength) {
+boolean PubSubClient::publish(const char* topic, const uint8_t* payload, size_t plength) {
     return publish(topic, payload, plength, false);
 }
 
-boolean PubSubClient::publish(const char* topic, const uint8_t* payload, unsigned int plength, boolean retained) {
+boolean PubSubClient::publish(const char* topic, const uint8_t* payload, size_t plength, boolean retained) {
     if (connected()) {
-        if (this->bufferSize < MQTT_MAX_HEADER_SIZE + 2+strnlen(topic, this->bufferSize) + plength) {
+        if (this->bufferSize < MQTT_MAX_HEADER_SIZE + 2 + strnlen(topic, this->bufferSize) + plength) {
             // Too long
             return false;
         }
@@ -475,7 +475,7 @@ boolean PubSubClient::publish_P(const char* topic, const char* payload, boolean 
     return publish_P(topic, (const uint8_t*)payload, payload ? strnlen(payload, this->bufferSize) : 0, retained);
 }
 
-boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsigned int plength, boolean retained) {
+boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, size_t plength, boolean retained) {
     uint8_t llen = 0;
     uint8_t digit;
     unsigned int rc = 0;
@@ -483,8 +483,8 @@ boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsig
     unsigned int pos = 0;
     unsigned int i;
     uint8_t header;
-    unsigned int len;
-    int expectedLength;
+    size_t len;
+    size_t expectedLength;
 
     if (!connected()) {
         return false;
@@ -523,7 +523,7 @@ boolean PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsig
     return (rc == expectedLength);
 }
 
-boolean PubSubClient::beginPublish(const char* topic, unsigned int plength, boolean retained) {
+boolean PubSubClient::beginPublish(const char* topic, size_t plength, boolean retained) {
     if (connected()) {
         // Send the header and variable length field
         size_t length = MQTT_MAX_HEADER_SIZE;

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -154,10 +154,10 @@ public:
    void disconnect();
    boolean publish(const char* topic, const char* payload);
    boolean publish(const char* topic, const char* payload, boolean retained);
-   boolean publish(const char* topic, const uint8_t * payload, unsigned int plength);
-   boolean publish(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
+   boolean publish(const char* topic, const uint8_t * payload, size_t plength);
+   boolean publish(const char* topic, const uint8_t * payload, size_t plength, boolean retained);
    boolean publish_P(const char* topic, const char* payload, boolean retained);
-   boolean publish_P(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
+   boolean publish_P(const char* topic, const uint8_t * payload, size_t plength, boolean retained);
    // Start to publish a message.
    // This API:
    //   beginPublish(...)
@@ -166,7 +166,7 @@ public:
    // Allows for arbitrarily large payloads to be sent without them having to be copied into
    // a new buffer and held in memory at one time
    // Returns 1 if the message was started successfully, 0 if there was an error
-   boolean beginPublish(const char* topic, unsigned int plength, boolean retained);
+   boolean beginPublish(const char* topic, size_t plength, boolean retained);
    // Finish off this publish message (started with beginPublish)
    // Returns 1 if the packet was sent successfully, 0 if there was an error
    int endPublish();

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -79,12 +79,12 @@
 #  ifdef __has_include
 #    if __has_include(<functional>)
 #      include <functional>
-#      define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)> callback
+#      define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, size_t)> callback
 #    else
-#      define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, unsigned int)
+#      define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, size_t)
 #    endif
 #  else
-#    define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, unsigned int)
+#    define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, size_t)
 #  endif
 
 #define CHECK_STRING_LENGTH(l,s) if (l+2+strnlen(s, this->bufferSize) > this->bufferSize) {_client->stop();return false;}


### PR DESCRIPTION
```
PubSubClient.cpp:523:16: warning: comparison of integer expressions of different signedness: 'unsigned int' and 'int' [-Wsign-compare]
  523 |     return (rc == expectedLength);
```
and replacing all relevant `unsigned int` by `size_t`