### PR TITLE
fix: keepalive behviour when set to 0

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -370,7 +370,7 @@ uint32_t PubSubClient::readPacket(uint8_t* lengthLength) {
 boolean PubSubClient::loop() {
     if (connected()) {
         unsigned long t = millis();
-        if ((t - lastInActivity > this->keepAlive*1000UL) || (t - lastOutActivity > this->keepAlive*1000UL)) {
+        if (((t - lastInActivity > this->keepAlive*1000UL) || (t - lastOutActivity > this->keepAlive*1000UL)) && keepAlive != 0) {
             if (pingOutstanding) {
                 this->_state = MQTT_CONNECTION_TIMEOUT;
                 _client->stop();


### PR DESCRIPTION
Setting keep alive to 0, or infinite keep alive, is not currently handled correctly.
Currently the client will immediately disconnect when keep alive is set to 0, this fix adds a check for this state before attempting PINGREQ.

See for reference: https://github.com/knolleary/pubsubclient/issues/1033 https://github.com/knolleary/pubsubclient/pull/1038