### PR TITLE
Implements fix described in https://github.com/knolleary/pubsubclient/issues/832

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -395,6 +395,7 @@ boolean PubSubClient::loop() {
                 if (type == MQTTPUBLISH) {
                     if (callback) {
                         uint16_t tl = (this->buffer[llen+1]<<8)+this->buffer[llen+2]; /* topic length in bytes */
+                        if(!(tl < bufferSize)) return false;
                         memmove(this->buffer+llen+2,this->buffer+llen+3,tl); /* move topic inside buffer 1 byte to front */
                         this->buffer[llen+2+tl] = 0; /* end the topic as a 'C' string with \x00 */
                         char *topic = (char*) this->buffer+llen+2;


### PR DESCRIPTION
Implements the oneliner fix suggested by arjenhiemstra to fix issue #832 (https://github.com/knolleary/pubsubclient/issues/832) on the main PubSubClient github.

This solves the issue where the ESP32 would crash if a Shared Attribute or RPC callback is received while we are uploading telemetry.