### PR TITLE
fix: connect() method - use correct buffer to write password into

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -247,7 +247,7 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
                 length = writeString(user,this->receive_buffer,length);
                 if(pass != NULL) {
                     CHECK_STRING_LENGTH(length,pass)
-                    length = writeString(pass,this->send_buffer,length);
+                    length = writeString(pass,this->receive_buffer,length);
                 }
             }
 


### PR DESCRIPTION
connect(): when using username & password, the password string was written to the wrong buffer, resulting in a corrupt MQTT connect packet and connection failure.