### PR TITLE
Fix keepalive handling (various issues in original issue tracker)

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -427,7 +427,9 @@ boolean PubSubClient::loop_read() {
             if (_client->connected()) {
                 receive_buffer[0] = MQTTPINGRESP;
                 receive_buffer[1] = 0;
-                _client->write(receive_buffer,2);
+                if (_client->write(receive_buffer,2) != 0) {
+                  lastOutActivity = t;
+                }
             }
             break;
         } 
@@ -627,6 +629,9 @@ boolean PubSubClient::write(uint8_t header, uint8_t* buf, uint16_t length) {
         result = (rc == bytesToWrite);
         bytesRemaining -= rc;
         writeBuf += rc;
+        if (rc != 0) {
+            lastOutActivity = millis();
+        }
     }
     return result;
 #else


### PR DESCRIPTION
Hi,
the original client has some problem with the state machine, which handles the keep alive packets. If the connection breaks and the client is waiting for a ping response, a reconnect with the same client will still wait for the pong response, as the state machine says `pingOutstanding` is true.

This code cleans it up a bit:
- on connection it makes sure that `pingOutstanding=false` (that's the main issue)
- it only sets it to true if it successfully sent the ping request
- when the connection is closed, the `pingOutstanding` state variable is also reset to false for safety
- it also makes sure that the timer is reset when publishing new topics and other places.

This fixes the issues mentioned in the original issue tracker: 
- https://github.com/knolleary/pubsubclient/issues/795
- https://github.com/knolleary/pubsubclient/issues/829
- https://github.com/knolleary/pubsubclient/issues/1059
- https://github.com/knolleary/pubsubclient/issues/810

This is mainly an improvement to the following pull request on original repo: https://github.com/knolleary/pubsubclient/pull/802

It would be nice to include this together with the urgent fix to unbreak passing a password on connect.

I am testing this at moment together with the PR #11 with the device BSB-LAN (for heaters): https://github.com/fredlcore/BSB-LAN/pull/683