### PR TITLE
Allow a few methods to be overridden by subclasses

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -154,12 +154,12 @@ public:
    boolean connect(const char* id, const char* user, const char* pass);
    boolean connect(const char* id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
    boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
-   boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, boolean cleanSession);
-   void disconnect();
+   virtual boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, boolean cleanSession);
+   virtual void disconnect();
    boolean publish(const char* topic, const char* payload);
    boolean publish(const char* topic, const char* payload, boolean retained);
    boolean publish(const char* topic, const uint8_t * payload, size_t plength);
-   boolean publish(const char* topic, const uint8_t * payload, size_t plength, boolean retained);
+   virtual boolean publish(const char* topic, const uint8_t * payload, size_t plength, boolean retained);
    boolean publish_P(const char* topic, const char* payload, boolean retained);
    boolean publish_P(const char* topic, const uint8_t * payload, size_t plength, boolean retained);
    // Start to publish a message.
@@ -180,11 +180,11 @@ public:
    // Returns the number of bytes written
    virtual size_t write(const uint8_t *buffer, size_t size);
    boolean subscribe(const char* topic);
-   boolean subscribe(const char* topic, uint8_t qos);
+   virtual boolean subscribe(const char* topic, uint8_t qos);
    boolean unsubscribe(const char* topic);
    boolean loop_read();
-   boolean loop();
-   boolean connected();
+   virtual boolean loop();
+   virtual boolean connected();
    int state();
 
 };


### PR DESCRIPTION
Background in https://github.com/meshtastic/firmware/pull/5724. I'd like to contribute some unit tests to the Meshtastic project. Right now I'm mocking at the level of the `Client` and needing to implement a small MQTT server inside the unit tests. That isn't ideal as the unit tests are somewhat tied to the implementation details of PubSubClient. Having virtual methods would allow for mocking these methods directly and reduce the code required for writing unit tests for clients of PubSubClient.