### PR TITLE
Add method to reset client to null

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -194,9 +194,11 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
 }
 
 boolean PubSubClient::connect(const char *id, const char *user, const char *pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, boolean cleanSession) {
+    if (_client == NULL) {
+        return false;
+    }
     if (!connected()) {
         int result = 0;
-
 
         if(_client->connected()) {
             result = 1;
@@ -459,6 +461,9 @@ boolean PubSubClient::loop_read() {
 }
 
 boolean PubSubClient::loop() {
+    if (_client == NULL) {
+        return false;
+    }
     loop_read();
     if (connected()) {
         unsigned long t = millis();
@@ -711,6 +716,9 @@ boolean PubSubClient::unsubscribe(const char* topic) {
 }
 
 void PubSubClient::disconnect() {
+    if (_client == NULL) {
+        return;
+    }
     this->send_buffer[0] = MQTTDISCONNECT;
     this->send_buffer[1] = 0;
     _client->write(this->send_buffer,2);
@@ -780,6 +788,13 @@ PubSubClient& PubSubClient::setCallback(MQTT_CALLBACK_SIGNATURE) {
 PubSubClient& PubSubClient::setClient(Client& client){
     this->_client = &client;
     return *this;
+}
+
+viod PubSubClient::resetClient() {
+    if (connected()) {
+        disconnect();
+    }
+    this->_client = NULL;
 }
 
 PubSubClient& PubSubClient::setStream(Stream& stream){

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -146,6 +146,8 @@ public:
    PubSubClient& setKeepAlive(uint16_t keepAlive);
    PubSubClient& setSocketTimeout(uint16_t timeout);
 
+   void resetClient();
+   
    boolean setBufferSize(uint16_t receive_size, uint16_t send_size);
    uint16_t getSendBufferSize();
    uint16_t getReceiveBufferSize();


### PR DESCRIPTION
In our usecase of PubSubClient we have multiple possible providers for a Client (Ethernet, WiFi, Gsm, ...)

This can change at runtime as providers have different priorities and they might get disconnected or reconnected.
This also means that at some time no client might be available, and a previously used client might get destroyed.

So I need ot be able to reset the _client property of PubSubClient to null. I added a method `resetClient()` for this purpose.

I also added some more guards on _client being null.